### PR TITLE
Refine README header and banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@
 <h1 align="center">Awesome Coding Agents for Robot Learning</h1>
 
 <p align="center">
-  <strong>The executable layer of agentic robot learning — from generated robot programs to agent-driven learning loops.</strong>
+  <strong>How coding agents write, run, and refine code for robot learning.</strong>
 </p>
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge-flat2.svg" alt="Awesome"></a>
-  <img src="https://img.shields.io/badge/Works-87-0B7285?style=flat" alt="87 works">
-  <img src="https://img.shields.io/badge/Open_source-42-0B7285?style=flat" alt="42 open-source works">
-  <img src="https://img.shields.io/badge/Real_robot-43-6F42C1?style=flat" alt="43 works with real-robot evaluation">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-4C566A?style=flat" alt="MIT License"></a>
-  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-0B7285?style=flat" alt="PRs welcome"></a>
+  <img src="https://img.shields.io/badge/Works-87-168B8F?style=flat-square" alt="87 works">
+  <img src="https://img.shields.io/badge/Open_source-42-168B8F?style=flat-square" alt="42 open-source works">
+  <img src="https://img.shields.io/badge/Real_robot-43-6C63D8?style=flat-square" alt="43 works with real-robot evaluation">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-536270?style=flat-square" alt="MIT License"></a>
+  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-168B8F?style=flat-square" alt="PRs welcome"></a>
 </p>
 
 <p align="center">
-  <a href="#-code-as-policy">🦾 Code as Policy</a> ·
-  <a href="#-environments-and-tasks">🌍 Environments &amp; Tasks</a> ·
-  <a href="#-reward-design">🎯 Reward Design</a>
+  <a href="#-code-as-policy"><code>Code as Policy</code></a>&nbsp;
+  <a href="#-environments-and-tasks"><code>Environments &amp; Tasks</code></a>&nbsp;
+  <a href="#-reward-design"><code>Reward Design</code></a>
   <br>
-  <a href="#-policy-evaluation">🔍 Policy Evaluation</a> ·
-  <a href="#-synthetic-data">📦 Synthetic Data</a> ·
-  <a href="#-robot-autoresearch">🔬 Robot Autoresearch</a>
+  <a href="#-policy-evaluation"><code>Policy Evaluation</code></a>&nbsp;
+  <a href="#-synthetic-data"><code>Synthetic Data</code></a>&nbsp;
+  <a href="#-robot-autoresearch"><code>Robot Autoresearch</code></a>
 </p>
 
 Robot learning is becoming **agent-editable**. Coding agents no longer only translate instructions into robot programs: they create and revise the executable artifacts around a robot policy — the policy itself, tasks and environments, rewards, evaluation scenarios, synthetic-data generators, and even the outer training loop.

--- a/README.md
+++ b/README.md
@@ -2,31 +2,30 @@
   <img src="assets/banner.svg" alt="Awesome Coding Agents for Robot Learning" width="100%">
 </div>
 
-<div align="center">
+<h1 align="center">Awesome Coding Agents for Robot Learning</h1>
 
-[![Awesome](https://awesome.re/badge-flat2.svg)](https://awesome.re)
-![Works](https://img.shields.io/badge/Works-87-2F80ED?style=flat-square)
-![Topics](https://img.shields.io/badge/Topics-6-6C5CE7?style=flat-square)
-![Open source](https://img.shields.io/badge/Open_source-42-00A86B?style=flat-square)
-![Real robot](https://img.shields.io/badge/Real_robot-43-E17055?style=flat-square)
-![Related systems](https://img.shields.io/badge/Related_systems-13-7F8C8D?style=flat-square)
-<br>
-![Code as Policy](https://img.shields.io/badge/Code_as_Policy-24-3867D6?style=flat-square)
-![Environments and Tasks](https://img.shields.io/badge/Environments_%26_Tasks-26-20BF6B?style=flat-square)
-![Reward Design](https://img.shields.io/badge/Reward_Design-23-F7B731?style=flat-square)
-![Policy Evaluation](https://img.shields.io/badge/Policy_Evaluation-6-EB3B5A?style=flat-square)
-![Synthetic Data](https://img.shields.io/badge/Synthetic_Data-22-8854D0?style=flat-square)
-![Robot Autoresearch](https://img.shields.io/badge/Robot_Autoresearch-2-0FB9B1?style=flat-square)
+<p align="center">
+  <strong>The executable layer of agentic robot learning — from generated robot programs to agent-driven learning loops.</strong>
+</p>
 
-[![Last commit](https://img.shields.io/github/last-commit/harooos/awesome-coding-agents-for-robot-learning?style=flat-square)](https://github.com/harooos/awesome-coding-agents-for-robot-learning/commits/main)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+<p align="center">
+  <a href="https://awesome.re"><img src="https://awesome.re/badge-flat2.svg" alt="Awesome"></a>
+  <img src="https://img.shields.io/badge/Works-87-0B7285?style=flat" alt="87 works">
+  <img src="https://img.shields.io/badge/Open_source-42-0B7285?style=flat" alt="42 open-source works">
+  <img src="https://img.shields.io/badge/Real_robot-43-6F42C1?style=flat" alt="43 works with real-robot evaluation">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-4C566A?style=flat" alt="MIT License"></a>
+  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-0B7285?style=flat" alt="PRs welcome"></a>
+</p>
 
-</div>
-
-# Awesome Coding Agents for Robot Learning
-
-**The executable layer of agentic robot learning — from generated robot programs to agent-driven learning loops.**
+<p align="center">
+  <a href="#-code-as-policy">🦾 Code as Policy</a> ·
+  <a href="#-environments-and-tasks">🌍 Environments &amp; Tasks</a> ·
+  <a href="#-reward-design">🎯 Reward Design</a>
+  <br>
+  <a href="#-policy-evaluation">🔍 Policy Evaluation</a> ·
+  <a href="#-synthetic-data">📦 Synthetic Data</a> ·
+  <a href="#-robot-autoresearch">🔬 Robot Autoresearch</a>
+</p>
 
 Robot learning is becoming **agent-editable**. Coding agents no longer only translate instructions into robot programs: they create and revise the executable artifacts around a robot policy — the policy itself, tasks and environments, rewards, evaluation scenarios, synthetic-data generators, and even the outer training loop.
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -72,4 +72,8 @@
     <text x="586" y="198" fill="#f2fbfc" font-size="62" font-weight="700" letter-spacing="-1.2">Awesome Coding Agents</text>
     <text x="586" y="269" fill="url(#accent)" font-size="62" font-weight="700" letter-spacing="-1.2">for Robot Learning</text>
   </g>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="18.5" font-weight="400">
+    <text x="590" y="326" fill="#58d8d3">//</text>
+    <text x="625" y="326" fill="#b8ced3">How coding agents write, run, and refine code for robot learning.</text>
+  </g>
 </svg>

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,60 +1,75 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 420" role="img" aria-labelledby="title desc">
   <title id="title">Awesome Coding Agents for Robot Learning</title>
-  <desc id="desc">A dark technical banner showing a stylized robot arm, code brackets, and the project title.</desc>
+  <desc id="desc">A refined dark technical banner with a stylized robot arm, subtle ASCII texture, code brackets, and the project title.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#07111f"/>
-      <stop offset="0.55" stop-color="#0b2234"/>
-      <stop offset="1" stop-color="#133b43"/>
+      <stop offset="0" stop-color="#07131f"/>
+      <stop offset="0.56" stop-color="#0a2130"/>
+      <stop offset="1" stop-color="#102f35"/>
     </linearGradient>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#37d5d6"/>
-      <stop offset="1" stop-color="#8b7cf6"/>
+      <stop offset="0" stop-color="#3dd6d0"/>
+      <stop offset="1" stop-color="#8d82f6"/>
     </linearGradient>
     <radialGradient id="glow" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#43e0d4" stop-opacity="0.22"/>
+      <stop offset="0" stop-color="#43e0d4" stop-opacity="0.16"/>
       <stop offset="1" stop-color="#43e0d4" stop-opacity="0"/>
     </radialGradient>
-    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#9fd8dc" stroke-opacity="0.07" stroke-width="1"/>
+    <radialGradient id="asciiFade" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#fff" stop-opacity="0.82"/>
+      <stop offset="0.64" stop-color="#fff" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#b5e1e3" stroke-opacity="0.045" stroke-width="1"/>
     </pattern>
-    <filter id="soft" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="18"/>
+    <pattern id="ascii" width="64" height="44" patternUnits="userSpaceOnUse">
+      <g fill="#70d8d6" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="10" font-weight="600">
+        <text x="4" y="13">0</text>
+        <text x="27" y="12">{</text>
+        <text x="49" y="15">1</text>
+        <text x="14" y="34">&lt;</text>
+        <text x="38" y="36">/</text>
+        <text x="57" y="34">&gt;</text>
+      </g>
+    </pattern>
+    <mask id="asciiMask">
+      <rect width="1600" height="420" fill="#000"/>
+      <ellipse cx="292" cy="210" rx="244" ry="184" fill="url(#asciiFade)"/>
+    </mask>
+    <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="24"/>
     </filter>
   </defs>
 
   <rect width="1600" height="420" rx="28" fill="url(#bg)"/>
   <rect width="1600" height="420" rx="28" fill="url(#grid)"/>
-  <circle cx="300" cy="210" r="210" fill="url(#glow)"/>
-  <circle cx="1320" cy="70" r="190" fill="#7768e8" opacity="0.08" filter="url(#soft)"/>
+  <rect x="1" y="1" width="1598" height="418" rx="27" fill="none" stroke="#d8f3f4" stroke-opacity="0.08"/>
+  <circle cx="298" cy="212" r="205" fill="url(#glow)"/>
+  <circle cx="1320" cy="62" r="176" fill="#796de5" opacity="0.055" filter="url(#soft)"/>
+  <rect x="46" y="22" width="500" height="376" fill="url(#ascii)" opacity="0.29" mask="url(#asciiMask)"/>
 
   <g transform="translate(92 54)" fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M68 286h280" stroke="#bddde1" stroke-opacity="0.24" stroke-width="3"/>
-    <path d="M130 276v-54h88" stroke="#e8fbfb" stroke-width="18"/>
-    <circle cx="130" cy="220" r="29" fill="#0c2634" stroke="url(#accent)" stroke-width="10"/>
-    <path d="M150 201l70-78" stroke="#e8fbfb" stroke-width="22"/>
-    <circle cx="222" cy="121" r="28" fill="#0c2634" stroke="url(#accent)" stroke-width="10"/>
-    <path d="M247 130l78 47" stroke="#e8fbfb" stroke-width="20"/>
-    <circle cx="331" cy="180" r="24" fill="#0c2634" stroke="url(#accent)" stroke-width="9"/>
-    <path d="M347 163l34-34" stroke="#e8fbfb" stroke-width="16"/>
+    <path d="M68 286h280" stroke="#bddde1" stroke-opacity="0.19" stroke-width="3"/>
+    <path d="M130 276v-54h88" stroke="#dceff1" stroke-width="18"/>
+    <circle cx="130" cy="220" r="29" fill="#0b2533" stroke="url(#accent)" stroke-width="10"/>
+    <circle cx="130" cy="220" r="7" fill="#5cddd7" stroke="none" opacity="0.9"/>
+    <path d="M150 201l70-78" stroke="#dceff1" stroke-width="22"/>
+    <circle cx="222" cy="121" r="28" fill="#0b2533" stroke="url(#accent)" stroke-width="10"/>
+    <circle cx="222" cy="121" r="7" fill="#8a83f2" stroke="none" opacity="0.9"/>
+    <path d="M247 130l78 47" stroke="#dceff1" stroke-width="20"/>
+    <circle cx="331" cy="180" r="24" fill="#0b2533" stroke="url(#accent)" stroke-width="9"/>
+    <circle cx="331" cy="180" r="6" fill="#55d9d2" stroke="none" opacity="0.9"/>
+    <path d="M347 163l34-34" stroke="#dceff1" stroke-width="16"/>
     <path d="M376 111l18 18-17 18M397 108l18 18" stroke="#49d8d2" stroke-width="8"/>
     <rect x="82" y="274" width="100" height="28" rx="14" fill="#172f3f" stroke="#54d7d2" stroke-width="3"/>
-    <path d="M35 98L4 132l31 34M441 98l31 34-31 34" stroke="#8b7cf6" stroke-width="9" opacity="0.8"/>
-    <path d="M72 72h122M72 92h86" stroke="#55d9d2" stroke-width="6" opacity="0.34"/>
+    <path d="M35 98L4 132l31 34M441 98l31 34-31 34" stroke="#8b7cf6" stroke-width="8" opacity="0.68"/>
+    <path d="M72 72h122M72 92h86M72 112h48" stroke="#55d9d2" stroke-width="5" opacity="0.27"/>
   </g>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
-    <text x="590" y="92" fill="#68ddd7" font-size="20" font-weight="700" letter-spacing="4">CURATED RESEARCH MAP</text>
-    <text x="586" y="178" fill="#f2fbfc" font-size="62" font-weight="760" letter-spacing="-1">Awesome Coding Agents</text>
-    <text x="586" y="248" fill="url(#accent)" font-size="62" font-weight="760" letter-spacing="-1">for Robot Learning</text>
-    <text x="590" y="302" fill="#b8ced3" font-size="23" font-weight="420">Executable policies · simulation tasks · rewards · evaluation</text>
-    <text x="590" y="337" fill="#b8ced3" font-size="23" font-weight="420">synthetic data · agentic policy training</text>
-  </g>
-
-  <g transform="translate(1396 322)" fill="none" stroke="url(#accent)" stroke-width="4" opacity="0.75">
-    <circle cx="0" cy="0" r="10" fill="#102c39"/>
-    <circle cx="52" cy="0" r="10" fill="#102c39"/>
-    <circle cx="104" cy="0" r="10" fill="#102c39"/>
-    <path d="M10 0h32M62 0h32"/>
+    <text x="590" y="112" fill="#68ddd7" font-size="19" font-weight="700" letter-spacing="4.2">CURATED RESEARCH MAP</text>
+    <text x="586" y="198" fill="#f2fbfc" font-size="62" font-weight="700" letter-spacing="-1.2">Awesome Coding Agents</text>
+    <text x="586" y="269" fill="url(#accent)" font-size="62" font-weight="700" letter-spacing="-1.2">for Robot Learning</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- refine the README header hierarchy and badge styling
- add subtle ASCII/coding texture to the robot-learning banner
- add a concise `//` subtitle describing the repository scope

## Validation
- validated `assets/banner.svg` as well-formed XML
- checked the staged diff with `git diff --check`